### PR TITLE
#60 キーワードグループ重複エラーが発生する

### DIFF
--- a/tools/migrations/model/KeywordGroup.go
+++ b/tools/migrations/model/KeywordGroup.go
@@ -7,8 +7,8 @@ import (
 // KeywordGroup（正規化された技術キーワード）
 type KeywordGroup struct {
 	KeywordGroupID uint   `gorm:"primaryKey;autoIncrement"`
-	Name           string `gorm:"unique;size:255;not null"`
-	Type           string `gorm:"type:enum('language','framework','must','want','other');not null"`
+	Name           string `gorm:"size:255;not null;"`
+	Type           string `gorm:"type:enum('language','framework','must','want','other');not null;"`
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 


### PR DESCRIPTION
一旦制約を解除する。
最悪マスタの手入れは後で考えれば良い。